### PR TITLE
Feature/use latest scikit learn

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -67,23 +67,17 @@ def train_model(X_train, y_train, X_test, y_test, lmd):
     # input: dataset X and labels y (in {+1, -1}
 
     # Preprocessing data
-    imputer = SimpleImputer()
-    # scaler = preprocessing.MinMaxScaler()
-    scaler = preprocessing.StandardScaler()
-    normalizer = preprocessing.Normalizer()
-    centerer = preprocessing.KernelCenterer()
-
+    # imputer = SimpleImputer()
+    scaler = preprocessing.StandardScaler()     # standardize features
+    normalizer = preprocessing.Normalizer()     # normalize samples
 
     # X = imputer.fit_transform(X)
     X_train = scaler.fit_transform(X_train)
     X_train = normalizer.fit_transform(X_train)
-    X_train = centerer.fit_transform(X_train)
 
     # X_test = imputer.fit_transform(X_test)
     X_test = scaler.fit_transform(X_test)
     X_test = normalizer.fit_transform(X_test)
-    X_test = centerer.fit_transform(X_test)
-
 
     ## Adaboost
     print('\nAdaboost')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dwave-ocean-sdk==2.1.1
 pandas==0.25.3
 scipy==1.1.0
-scikit-learn==0.20.3
+scikit-learn==0.22.2.post1
 jupyter==1.0.0
 
 matplotlib==3.1.3; python_version>'3.5'


### PR DESCRIPTION
Closes #2 

* code changes to allow for newer scikit-learn (`0.22.2.post1`)
* please see commit 02c58c3 for details on the removal of KernelCenterer
* note: scikit-learn released 0.23.0 yesterday, but it doesn't support py 3.5. Hence I am just grabbing the latest scikit-learn that supports py 3.5 through 3.8.