### PR TITLE
Compatibility fix for scikit-learn 0.24

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -183,7 +183,8 @@ if __name__ == '__main__':
 
         print('MNIST handwritten digits data set:')
 
-        mnist = fetch_openml('mnist_784', version=1)
+        # Note: as_frame default changed between scikit-learn 0.23 and 0.24
+        mnist = fetch_openml('mnist_784', version=1, as_frame=False)
 
         idx = np.arange(len(mnist['data']))
         np.random.shuffle(idx)


### PR DESCRIPTION
The default value of `as_frame` in `fetch_openml` changed in 0.24, which broke the "mnist" demo when used with sklearn 0.24.  This fix is compatible with both sklearn 0.23 and 0.24.