### PR TITLE
Add matplotlib to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ dwave-ocean-sdk>=3.3.0
 scikit-learn==0.23.1; python_version>='3.6'
 scikit-learn==0.22.2.post1; python_version<'3.6'
 tabulate>=0.8.7
+matplotlib==3.3.4; python_version>'3.5'
+matplotlib==3.0.3; python_version=='3.5'


### PR DESCRIPTION
Requested by user.  Matplotlib is used with the command option `python demo.py digits --plot-digits`.