### PR TITLE
Update scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 dwave-ocean-sdk>=3.3.0
-scikit-learn==0.23.1; python_version>='3.6'
-scikit-learn==0.22.2.post1; python_version<'3.6'
+scikit-learn==0.23.1
 tabulate>=0.8.7
-matplotlib==3.3.4; python_version>'3.5'
-matplotlib==3.0.3; python_version=='3.5'
+matplotlib==3.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dwave-ocean-sdk>=3.3.0
-scikit-learn==0.23.1
+scikit-learn==0.24.2
 tabulate>=0.8.7
 matplotlib==3.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dwave-ocean-sdk>=3.3.0
-scikit-learn==0.24.2
+scikit-learn==1.0
 tabulate>=0.8.7
 matplotlib==3.3.4


### PR DESCRIPTION
Closes #27 and also drops special handling for python 3.5.  Tested locally with Ocean 4.  I'm not sure how to test with Ocean 4 in the IDE, but based on the comments in #27, this should fix the incompatibility with the preinstalled `imbalanced-learn`.