### PR TITLE
Switch to scikit-learn 0.24.2 for python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dwave-ocean-sdk>=3.3.0
-scikit-learn==1.0
+scikit-learn==1.0; python_version>='3.7'
+scikit-learn==0.24.2; python_version=='3.6'
 tabulate>=0.8.7
 matplotlib==3.3.4


### PR DESCRIPTION
This reverts commit 5e6889d5f98b382be46048bd58c4e5e9152c3276.

Go back to scikit-learn 0.24.2, since 1.0 does not appear to be available in CI environment.