### PR TITLE
Simplify requirements for scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 dwave-ocean-sdk>=3.3.0
-scikit-learn==1.0; python_version>='3.7'
-scikit-learn==0.24.2; python_version=='3.6'
+scikit-learn<=1.0
 tabulate>=0.8.7
 matplotlib==3.3.4


### PR DESCRIPTION
Per @randomir's suggestion (https://github.com/dwave-examples/qboost/pull/29#discussion_r722069237), simplify requirements for `scikit-learn`.  Using `<2.0` would be an option as well, but without knowing more about their versioning, I'm inclined to stick with versions that we know will work.